### PR TITLE
修改 podspec

### DIFF
--- a/DFTimelineView.podspec
+++ b/DFTimelineView.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'DFCommon'
   s.dependency 'AFNetworking', '~> 3.0.0'
-  s.dependency 'SDWebImage', '~> 3.7.3'
+  s.dependency 'SDWebImage', '>= 3.7.3'
   s.dependency 'FMDB', '~> 2.5'
   s.dependency 'MBProgressHUD', '~> 0.9.1'
   s.dependency 'MLLabel', '~> 1.7'


### PR DESCRIPTION
由于SDWebImage 3.7.3 不支持https的图片加载，请修改为如上写法，这样我就能pod 4.0.0的。
而且如此修改 并不影响您当前的需求。
请尽快修改，上传。